### PR TITLE
Update board meeting time for 2015

### DIFF
--- a/data/board-meeting.conf
+++ b/data/board-meeting.conf
@@ -10,5 +10,5 @@ mail_on_rel_days=-1
 template=board-meeting.mail
 
 [template variables]
-hour=16
+hour=15
 minute=00


### PR DESCRIPTION
The board decide to move one hour earlier its meeting.
So 15 Geeko meridian time is active starting March 2015