### PR TITLE
Project meeting is no more automatic

### DIFF
--- a/data/project-meeting.conf
+++ b/data/project-meeting.conf
@@ -1,14 +1,16 @@
-[event]
-type=biweekly
-biweekly_week=0
+# On May 15th 2015, the project meeting is no more automatic
+# It's scheduled on demand
+#[event]
+#type=biweekly
+#biweekly_week=0
 # Meeting on Wednesday (Monday = 1)
-day=3
+#day=3
 
-[mail]
+#[mail]
 # Mail the day before
-mail_on_rel_days=-1
-template=project-meeting.mail
+#mail_on_rel_days=-1
+#template=project-meeting.mail
 
-[template variables]
-hour=15
-minute=00
+#[template variables]
+#hour=15
+#minute=00


### PR DESCRIPTION
On May 15th 2015 the project meeting on irc, is now scheduled on demand 
Send an email to opensuse-project to invite people to join.

Commented everything 