### PR TITLE
board-meeting.conf: Update board meeting time.

### DIFF
--- a/data/board-meeting.conf
+++ b/data/board-meeting.conf
@@ -1,14 +1,14 @@
 [event]
 type=biweekly
 biweekly_week=0
-# Meeting on Wednesday (Monday = 1)
+# (Monday = 1)
 day=2
 
 [mail]
-# Mail the day before
-mail_on_rel_days=-1
+# Mail two days before
+mail_on_rel_days=-2
 template=board-meeting.mail
 
 [template variables]
-hour=22
+hour=8
 minute=00


### PR DESCRIPTION
Reflect the (temporary) move of the board meeting to Tuesday, 8:00 CEST.
On the way send this reminder two days in advance.