### PR TITLE
Update board-meeting.mail

### DIFF
--- a/data/board-meeting.mail
+++ b/data/board-meeting.mail
@@ -1,5 +1,5 @@
 From: openSUSE Meeting Reminder <no-reply@opensuse.org>
-To: board@opensuse.org
+To: project@lists.opensuse.org ; board@lists.opensuse.org
 Subject: [reminder] Board Conf Call next Monday at %(hour)s:%(minute)s NUE Time
 
 Hello all,


### PR DESCRIPTION
We want to invite openSUSE users to the public board meeting, so need to send a mail to project@ as well as board@.
Not sure the tool copes with 2 addresses